### PR TITLE
Fix linking order in CMake.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(rendercommon STATIC ${COMMON_FILES})
 
 function(add_example BIN_NAME SRC_NAME)
   add_executable(${BIN_NAME} ${SRC_NAME})
-  target_link_libraries(${BIN_NAME} ${EGL_LIBRARIES} ${GLESv2_LIBRARIES} ${X11_X11_LIB} m rendercommon)
+  target_link_libraries(${BIN_NAME} rendercommon ${EGL_LIBRARIES} ${GLESv2_LIBRARIES} ${X11_X11_LIB} m)
   if (ARGV2)
     target_compile_definitions(${BIN_NAME} PRIVATE ${ARGV2})
   endif()


### PR DESCRIPTION
Linking fails on Ubuntu 17.10, with gcc 7.2.0.

rendercommon uses functions from X11 and EGL, too, but because of the order the linker cannot find them. The beginning of the error log is:

```
librendercommon.a(render_common.c.o): In function `egl_query_surface_int':
render_common.c:(.text+0x2d): undefined reference to `eglQuerySurface'
librendercommon.a(render_common.c.o): In function `egl_get_config_attrib_int':
render_common.c:(.text+0x77): undefined reference to `eglGetConfigAttrib'
librendercommon.a(render_common.c.o): In function `egl_query_context_int':
render_common.c:(.text+0xc1): undefined reference to `eglQueryContext'
....
```